### PR TITLE
【単元2_追加課題1】フォームのバリデーション強化

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-hook-form": "^7.54.2",
+        "react-phone-number-input": "^3.4.11",
         "react-router-dom": "^7.1.3",
         "react-router-hash-link": "^2.4.3",
         "react-scripts": "5.0.1",
@@ -5288,6 +5289,12 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.1.tgz",
       "integrity": "sha512-cuSVIHi9/9E/+821Qjdvngor+xpnlwnuwIyZOaLmHBVdXL+gP+I6QQB9VkO7RI77YIcTV+S1W9AreJ5eN63JBA=="
     },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
+    },
     "node_modules/clean-css": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.3.tgz",
@@ -5613,6 +5620,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/country-flag-icons": {
+      "version": "1.5.16",
+      "resolved": "https://registry.npmjs.org/country-flag-icons/-/country-flag-icons-1.5.16.tgz",
+      "integrity": "sha512-F9lNvhSrJ9D7Y2a6Tvbx2MFglZ9esNK76uTy4NqvdVzvgvy6/cKMGDYcnR1QOCgtmdc+akz2gqibZn3e3b6rQA==",
+      "license": "MIT"
     },
     "node_modules/cra-template": {
       "version": "1.2.0",
@@ -8595,6 +8608,27 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
+    "node_modules/input-format": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/input-format/-/input-format-0.3.14.tgz",
+      "integrity": "sha512-gHMrgrbCgmT4uK5Um5eVDUohuV9lcs95ZUUN9Px2Y0VIfjTzT2wF8Q3Z4fwLFm7c5Z2OXCm53FHoovj6SlOKdg==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "react": ">=18.1.0",
+        "react-dom": ">=18.1.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -10316,6 +10350,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/libphonenumber-js": {
+      "version": "1.11.19",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.11.19.tgz",
+      "integrity": "sha512-bW/Yp/9dod6fmyR+XqSUL1N5JE7QRxQ3KrBIbYS1FTv32e5i3SEtQVX+71CYNv8maWNSOgnlCoNp9X78f/cKiA==",
+      "license": "MIT"
     },
     "node_modules/lilconfig": {
       "version": "2.1.0",
@@ -12888,6 +12928,23 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+    },
+    "node_modules/react-phone-number-input": {
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/react-phone-number-input/-/react-phone-number-input-3.4.11.tgz",
+      "integrity": "sha512-ypN9hXwUModpngho9brCHLLD40xzb1DKAZFacbF0J+fFaMVLEJo+zul9sZfSRlKehSjpttT4b1pLMcOWXI228g==",
+      "license": "MIT",
+      "dependencies": {
+        "classnames": "^2.5.1",
+        "country-flag-icons": "^1.5.11",
+        "input-format": "^0.3.10",
+        "libphonenumber-js": "^1.11.17",
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.11.0",
@@ -19872,6 +19929,11 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.1.tgz",
       "integrity": "sha512-cuSVIHi9/9E/+821Qjdvngor+xpnlwnuwIyZOaLmHBVdXL+gP+I6QQB9VkO7RI77YIcTV+S1W9AreJ5eN63JBA=="
     },
+    "classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
+    },
     "clean-css": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.3.tgz",
@@ -20128,6 +20190,11 @@
         "path-type": "^4.0.0",
         "yaml": "^1.10.0"
       }
+    },
+    "country-flag-icons": {
+      "version": "1.5.16",
+      "resolved": "https://registry.npmjs.org/country-flag-icons/-/country-flag-icons-1.5.16.tgz",
+      "integrity": "sha512-F9lNvhSrJ9D7Y2a6Tvbx2MFglZ9esNK76uTy4NqvdVzvgvy6/cKMGDYcnR1QOCgtmdc+akz2gqibZn3e3b6rQA=="
     },
     "cra-template": {
       "version": "1.2.0",
@@ -22233,6 +22300,14 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
+    "input-format": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/input-format/-/input-format-0.3.14.tgz",
+      "integrity": "sha512-gHMrgrbCgmT4uK5Um5eVDUohuV9lcs95ZUUN9Px2Y0VIfjTzT2wF8Q3Z4fwLFm7c5Z2OXCm53FHoovj6SlOKdg==",
+      "requires": {
+        "prop-types": "^15.8.1"
+      }
+    },
     "internal-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -23468,6 +23543,11 @@
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
       }
+    },
+    "libphonenumber-js": {
+      "version": "1.11.19",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.11.19.tgz",
+      "integrity": "sha512-bW/Yp/9dod6fmyR+XqSUL1N5JE7QRxQ3KrBIbYS1FTv32e5i3SEtQVX+71CYNv8maWNSOgnlCoNp9X78f/cKiA=="
     },
     "lilconfig": {
       "version": "2.1.0",
@@ -25136,6 +25216,18 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+    },
+    "react-phone-number-input": {
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/react-phone-number-input/-/react-phone-number-input-3.4.11.tgz",
+      "integrity": "sha512-ypN9hXwUModpngho9brCHLLD40xzb1DKAZFacbF0J+fFaMVLEJo+zul9sZfSRlKehSjpttT4b1pLMcOWXI228g==",
+      "requires": {
+        "classnames": "^2.5.1",
+        "country-flag-icons": "^1.5.11",
+        "input-format": "^0.3.10",
+        "libphonenumber-js": "^1.11.17",
+        "prop-types": "^15.8.1"
+      }
     },
     "react-refresh": {
       "version": "0.11.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.54.2",
+    "react-phone-number-input": "^3.4.11",
     "react-router-dom": "^7.1.3",
     "react-router-hash-link": "^2.4.3",
     "react-scripts": "5.0.1",

--- a/src/components/Contact/Contact.tsx
+++ b/src/components/Contact/Contact.tsx
@@ -5,11 +5,11 @@ import PhoneInput, { isValidPhoneNumber } from 'react-phone-number-input';
 import 'react-phone-number-input/style.css';
 
 const Contact = () => {
-  const { register, handleSubmit, control, formState: { errors, isSubmitting }, reset } = useForm({
+  const { register, handleSubmit, control, formState: { errors, isSubmitting }, reset, watch } = useForm({
     mode: "onChange",
     defaultValues: {
       name: "",
-      emails: [{ email: "" }],
+      emails: [{ email: "", confirmEmail: "" }],
       tels: [{ tel: "" }],
       message: ""
     }
@@ -64,12 +64,28 @@ const Contact = () => {
               {errors.emails?.[index]?.email && (
                 <p style={{ color: "red" }}>{errors.emails?.[index]?.email?.message}</p>
               )}
+
+              <input
+                {...register(`emails.${index}.confirmEmail`, {
+                  required: "確認用メールアドレスを入力してください。",
+                  validate: (value) => {
+                    const emails = watch(`emails.${index}.email`);
+                    return value === emails || "メールアドレスが一致しません。";
+                  }
+                })}
+                type="email"
+                placeholder="メールアドレス（確認用）"
+              />
+              {errors.emails?.[index]?.confirmEmail && (
+                <p style={{ color: "red" }}>{errors.emails?.[index]?.confirmEmail?.message}</p>
+              )}
+
               {emailFields.length > 1 && (
                 <button type="button" onClick={() => removeEmail(index)}>メールアドレスを削除</button>
               )}
             </div>
           ))}
-          <button type="button" onClick={() => appendEmail({ email: "" })}>
+          <button type="button" onClick={() => appendEmail({ email: "", confirmEmail: "" })}>
             メールアドレスを追加
           </button>
 

--- a/src/components/Contact/Contact.tsx
+++ b/src/components/Contact/Contact.tsx
@@ -1,6 +1,9 @@
 import styles from "./Contact.module.css";
 import { useForm, useFieldArray } from "react-hook-form";
 import { useState } from "react";
+import PhoneInput from 'react-phone-number-input';
+import 'react-phone-number-input/style.css';
+
 const Contact = () => {
   const { register, handleSubmit, control, formState: { errors, isSubmitting }, reset } = useForm({
     mode: "onChange",
@@ -72,14 +75,20 @@ const Contact = () => {
 
           {telFields.map((field, index) => (
             <div key={field.id} className={styles.inputContainer}>
-              <input
-                {...register(`tels.${index}.tel`, {
-                  pattern: {
-                    value: /^[0-9]+$/,
-                    message: "電話番号は数字のみで入力してください。",
-                  },
-                })}
-                type="tel"
+              <PhoneInput
+                international
+                defaultCountry="JP"
+                {...register(`tels.${index}.tel`)}
+                onChange={(value) => {
+                  // PhoneInputの値を手動でフォームに設定
+                  const event = {
+                    target: {
+                      name: `tels.${index}.tel`,
+                      value: value || ''
+                    }
+                  };
+                  register(`tels.${index}.tel`).onChange(event);
+                }}
                 placeholder="電話番号"
               />
               {errors.tels?.[index]?.tel && (

--- a/src/components/Contact/Contact.tsx
+++ b/src/components/Contact/Contact.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from "react";
 import PhoneInput, { isValidPhoneNumber } from 'react-phone-number-input';
 import 'react-phone-number-input/style.css';
 import { PostalCode } from "../../types/postalCode";
+
 const Contact = () => {
   const { register, handleSubmit, control, formState: { errors, isSubmitting }, reset, setValue, watch } = useForm({
     mode: "onChange",
@@ -31,14 +32,23 @@ const Contact = () => {
 
   const postalCode = watch("postalCode");
 
+  const isPostalCodeResponse = (data: any): data is PostalCode => {
+    return (
+      typeof data === 'object' &&
+      data !== null &&
+      'results' in data &&
+      (data.results === null || Array.isArray(data.results))
+    );
+  };
+
   const fetchAddress = useCallback(async (postalCode: string) => {
     if (postalCode.length === 7) {
       try {
         const response = await fetch(
           `https://zipcloud.ibsnet.co.jp/api/search?zipcode=${postalCode}`
         );
-        const data: PostalCode = await response.json();
-        if (data.results) {
+        const data = await response.json();
+        if (isPostalCodeResponse(data) && data.results) {
           const address = `${data.results[0].address1}${data.results[0].address2}${data.results[0].address3}`;
           setValue("address", address);
         }

--- a/src/components/Contact/Contact.tsx
+++ b/src/components/Contact/Contact.tsx
@@ -1,7 +1,7 @@
 import styles from "./Contact.module.css";
 import { useForm, useFieldArray } from "react-hook-form";
 import { useState } from "react";
-import PhoneInput from 'react-phone-number-input';
+import PhoneInput, { isValidPhoneNumber } from 'react-phone-number-input';
 import 'react-phone-number-input/style.css';
 
 const Contact = () => {
@@ -78,9 +78,14 @@ const Contact = () => {
               <PhoneInput
                 international
                 defaultCountry="JP"
-                {...register(`tels.${index}.tel`)}
+                {...register(`tels.${index}.tel`, {
+                  validate: (value) => {
+                    if (!value) return "電話番号を入力してください。";
+                    if (!isValidPhoneNumber(value)) return "有効な電話番号を入力してください。";
+                    return true;
+                  }
+                })}
                 onChange={(value) => {
-                  // PhoneInputの値を手動でフォームに設定
                   const event = {
                     target: {
                       name: `tels.${index}.tel`,

--- a/src/components/Contact/Contact.tsx
+++ b/src/components/Contact/Contact.tsx
@@ -3,7 +3,7 @@ import { useForm, useFieldArray } from "react-hook-form";
 import { useState, useEffect, useCallback } from "react";
 import PhoneInput, { isValidPhoneNumber } from 'react-phone-number-input';
 import 'react-phone-number-input/style.css';
-
+import { PostalCode } from "../../types/postalCode";
 const Contact = () => {
   const { register, handleSubmit, control, formState: { errors, isSubmitting }, reset, setValue, watch } = useForm({
     mode: "onChange",
@@ -37,7 +37,7 @@ const Contact = () => {
         const response = await fetch(
           `https://zipcloud.ibsnet.co.jp/api/search?zipcode=${postalCode}`
         );
-        const data = await response.json();
+        const data: PostalCode = await response.json();
         if (data.results) {
           const address = `${data.results[0].address1}${data.results[0].address2}${data.results[0].address3}`;
           setValue("address", address);

--- a/src/components/Contact/Contact.tsx
+++ b/src/components/Contact/Contact.tsx
@@ -5,12 +5,14 @@ import PhoneInput, { isValidPhoneNumber } from 'react-phone-number-input';
 import 'react-phone-number-input/style.css';
 
 const Contact = () => {
-  const { register, handleSubmit, control, formState: { errors, isSubmitting }, reset, watch } = useForm({
+  const { register, handleSubmit, control, formState: { errors, isSubmitting }, reset } = useForm({
     mode: "onChange",
     defaultValues: {
       name: "",
       emails: [{ email: "", confirmEmail: "" }],
       tels: [{ tel: "" }],
+      postalCode: "",
+      address: "",
       message: ""
     }
   });
@@ -64,22 +66,6 @@ const Contact = () => {
               {errors.emails?.[index]?.email && (
                 <p style={{ color: "red" }}>{errors.emails?.[index]?.email?.message}</p>
               )}
-
-              <input
-                {...register(`emails.${index}.confirmEmail`, {
-                  required: "確認用メールアドレスを入力してください。",
-                  validate: (value) => {
-                    const emails = watch(`emails.${index}.email`);
-                    return value === emails || "メールアドレスが一致しません。";
-                  }
-                })}
-                type="email"
-                placeholder="メールアドレス（確認用）"
-              />
-              {errors.emails?.[index]?.confirmEmail && (
-                <p style={{ color: "red" }}>{errors.emails?.[index]?.confirmEmail?.message}</p>
-              )}
-
               {emailFields.length > 1 && (
                 <button type="button" onClick={() => removeEmail(index)}>メールアドレスを削除</button>
               )}
@@ -123,6 +109,29 @@ const Contact = () => {
           <button type="button" onClick={() => appendTel({ tel: "" })}>
             電話番号を追加
           </button>
+
+          <div className={styles.inputContainer}>
+            <input
+              {...register("postalCode", {
+                required: "郵便番号を入力してください。",
+                pattern: {
+                  value: /^\d{7}$/,
+                  message: "郵便番号は7桁の数字で入力してください。",
+                }
+              })}
+              placeholder="郵便番号（ハイフンなし）"
+              style={{ width: "50%" }}
+            />
+            {errors.postalCode && <p style={{ color: "red" }}>{errors.postalCode.message}</p>}
+          </div>
+
+          <div className={styles.inputContainer}>
+            <input
+              {...register("address", { required: "住所を入力してください。" })}
+              placeholder="住所"
+            />
+            {errors.address && <p style={{ color: "red" }}>{errors.address.message}</p>}
+          </div>
 
           <div className={styles.inputContainer}>
             <textarea

--- a/src/types/postalCode.d.ts
+++ b/src/types/postalCode.d.ts
@@ -1,0 +1,14 @@
+export interface PostalCode {
+  status: number;
+  message: string | null;
+  results: {
+    address1: string;
+    address2: string;
+    address3: string;
+    kana1: string;
+    kana2: string;
+    kana3: string;
+    prefcode: string;
+    zipcode: string;
+  }[] | null;
+}


### PR DESCRIPTION
## 概要
- Contact コンポーネントのフォームバリデーションを強化

## 実装詳細
- 電話番号入力の国際対応（国コード選択）
  - [react-phone-number-input](https://gitlab.com/catamphetamine/react-phone-number-input) を使用
- メール確認用再入力フィールド
- 郵便番号自動検索機能
- カスタムバリデーションルールの型安全な実装

## イメージ

<img width="1019" alt="スクリーンショット 2025-02-14 22 38 55" src="https://github.com/user-attachments/assets/ed5998d5-743b-47f6-a392-e42ec3d09ab3" />

